### PR TITLE
add scripts for android

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "start": "expo start",
     "android": "expo start --android",
     "ios": "expo start --ios",
-    "web": "expo start --web"
+    "web": "expo start --web",
+    "build:staging": "eas build -p android --profile staging --non-interactive",
+    "build:production": "eas build -p android --profile production --non-interactive"
   },
   "dependencies": {
     "@apollo/client": "^3.6.9",


### PR DESCRIPTION
apple builds are not included because it needs a paid apple developer account